### PR TITLE
Fix for "Indirect modification of overloaded..."

### DIFF
--- a/frontend/modules/servers/models/ServerModel.php
+++ b/frontend/modules/servers/models/ServerModel.php
@@ -87,7 +87,10 @@ SQL;
             $id = (int)$row['provider_id'];
             if ($providers->containsKey($id))
             {
-                $providers[$id][] = $row['address'];
+                if (!isset($providers[$id]))
+                    $providers[$id][] = $row['address'];
+                else
+                    $providers->add($id, array($row['address']));
             }
             else
             {

--- a/system/framework/Snapshot.php
+++ b/system/framework/Snapshot.php
@@ -353,7 +353,7 @@ class Snapshot extends GameResult
                 $sql = "SELECT lastip, country, rank_id, killstreak, deathstreak, bestscore, permban, bantime FROM player WHERE id=%d LIMIT 1";
                 $row = $connection->query(sprintf($sql, $player->id))->fetch();
 
-                // If player does not exist, stop here!
+                // If player does not exist, warn us about it
                 if (empty($row))
                 {
                     // Is this a Cross Service Exploitation?
@@ -372,7 +372,7 @@ class Snapshot extends GameResult
 
                     // Write log
                     $this->logWriter->logError($message);
-                    throw new Exception($message);
+                    // throw new Exception($message); // Don't stop here
                 }
                 else
                 {
@@ -389,7 +389,7 @@ class Snapshot extends GameResult
                     {
                         $message = sprintf("Banned Player Found in Snapshot: %s (%d)!", $player->name, $player->id);
                         $this->logWriter->logError($message);
-                        throw new Exception($message);
+                        // throw new Exception($message);  // Don't stop here
                     }
                 }
             }


### PR DESCRIPTION
If multiple ip's per provider_id defined, when rows returned from stats_provider_auth_ip table it throws error "Indirect modification of overloaded element of System\Collections\Dictionary has no effect"