### PR TITLE
Fix apache_get_version PHP error

### DIFF
--- a/frontend/modules/home/Home.php
+++ b/frontend/modules/home/Home.php
@@ -36,6 +36,16 @@ class Home extends Controller
         // Load model
         $this->loadModel('HomeModel', 'home');
 
+        // check to see if the function apache_get_version exists
+        // If it doesn’t, then we create a custom function that returns whatever string is stored in the SERVER_SOFTWARE superglobals variable.
+        if(!function_exists('apache_get_version')){
+            function apache_get_version(){
+                if(!isset($_SERVER['SERVER_SOFTWARE']) || strlen($_SERVER['SERVER_SOFTWARE']) == 0){
+                    return false;
+                }
+                return $_SERVER["SERVER_SOFTWARE"];
+            }
+        }
         // Create view
         $view = new View('index', 'home');
         $view->set('php_version', PHP_VERSION);


### PR DESCRIPTION
This fixes "Call to undefined function apache_get_version()" on linux where PHP has not been compiled to run as a normal Apache module.

Credit: https://thisinterestsme.com/undefined-function-apache_get_version/